### PR TITLE
Support for UITableView editing style handling

### DIFF
--- a/DAModularTableView/DAModularTableRow.h
+++ b/DAModularTableView/DAModularTableRow.h
@@ -10,20 +10,28 @@
 
 @interface DAModularTableRow : NSObject
 
-@property (nonatomic, copy) NSString *text;
-@property (nonatomic, copy) NSString *detailText;
-@property (nonatomic, copy) UIImage *image;
-@property (nonatomic, copy) UIView *accessoryView;
+@property (nonatomic, strong) NSString *text;
+@property (nonatomic, strong) NSString *detailText;
+@property (nonatomic, strong) UIImage *image;
+@property (nonatomic, strong) UIView *accessoryView;
+@property (nonatomic, strong) UIView *editingAccessoryView;
 
 @property (nonatomic) CGFloat rowHeight;
 
 @property (nonatomic) UITableViewCellSelectionStyle selectionStyle;
+@property (nonatomic) UITableViewCellEditingStyle editingStyle;
 @property (nonatomic) UITableViewCellAccessoryType accessoryType;
+@property (nonatomic) UITableViewCellAccessoryType editingAccessoryType;
 @property (nonatomic) UITableViewCellStyle cellStyle;
+@property (nonatomic) NSString *cellIdentifier;
 @property (nonatomic) UITableViewRowAnimation rowAnimation;
+@property (nonatomic) BOOL canBeMoved;
+@property (nonatomic) BOOL shouldIndentWhileEditing;
 
 @property (nonatomic, copy) void(^didSelectBlock)(NSIndexPath *indexPath);
+@property (nonatomic, copy) void(^accessoryButtonDidSelectBlock)(NSIndexPath *indexPath);
 @property (nonatomic, copy) void(^cellForRowBlock)(UITableViewCell *cell, NSIndexPath *indexPath);
+@property (nonatomic, copy) NSIndexPath *(^targetIndexPathForMoveFromRowAtIndexPath)(NSIndexPath *indexPath);
 @property (nonatomic) SEL didSelectAction;
 
 + (DAModularTableRow *)row;

--- a/DAModularTableView/DAModularTableRow.m
+++ b/DAModularTableView/DAModularTableRow.m
@@ -10,10 +10,12 @@
 
 @implementation DAModularTableRow
 
-@synthesize text, detailText, image, accessoryView;
+@synthesize text, detailText, image, accessoryView, editingAccessoryView;
 @synthesize rowHeight;
-@synthesize selectionStyle, accessoryType, cellStyle, rowAnimation;
-@synthesize didSelectBlock, cellForRowBlock, didSelectAction;
+@synthesize selectionStyle, accessoryType, cellStyle, editingStyle, rowAnimation;
+@synthesize canBeMoved;
+@synthesize didSelectBlock, cellForRowBlock, didSelectAction, accessoryButtonDidSelectBlock;
+@synthesize targetIndexPathForMoveFromRowAtIndexPath;
 
 #pragma mark - Public Methods
 
@@ -28,9 +30,13 @@
     if (self)
     {
         self.selectionStyle = UITableViewCellSelectionStyleBlue;
-        self.accessoryType = UITableViewCellAccessoryNone;
         self.cellStyle = UITableViewCellStyleDefault;
+        self.editingStyle = UITableViewCellEditingStyleNone;
+        self.accessoryType = UITableViewCellAccessoryNone;
+        self.editingAccessoryType = UITableViewCellAccessoryNone;
         self.rowAnimation = UITableViewRowAnimationAutomatic;
+        self.canBeMoved = NO;
+        self.shouldIndentWhileEditing = YES;
     }
     return self;
 }

--- a/DAModularTableView/DAModularTableView.h
+++ b/DAModularTableView/DAModularTableView.h
@@ -13,6 +13,10 @@
 
 @property (nonatomic, strong) NSMutableArray *sections;
 
+@property (nonatomic, copy) void(^rowMovedBlock)(NSIndexPath *sourceIndexPath, NSIndexPath *destinationIndexPath);
+@property (nonatomic, copy) void(^rowDeletedBlock)(NSIndexPath *indexPath);
+@property (nonatomic, copy) DAModularTableRow *(^rowInsertedBlock)(NSIndexPath *indexPath);
+
 #pragma mark - Accessing Rows, Sections, Cells and Index Paths
 
 - (DAModularTableSection *)sectionAtIndex:(NSInteger)index;
@@ -38,6 +42,8 @@
 
 - (void)reloadSection:(DAModularTableSection *)section
              animated:(BOOL)animated;
+
+- (void)removeAllSectionsAnimated:(BOOL)animated;
 
 #pragma mark - Inserting, Removing, Reloading Rows
 

--- a/DAModularTableView/DAModularTableViewController.h
+++ b/DAModularTableView/DAModularTableViewController.h
@@ -12,5 +12,10 @@
 @interface DAModularTableViewController : UITableViewController
 
 @property (nonatomic, strong) DAModularTableView *tableView;
+@property (nonatomic, assign) CGRect frame;
+
+@property (nonatomic, copy) void(^viewDidLoadBlock)();
+
+- (id)initWithFrame:(CGRect)aFrame style:(UITableViewStyle)aStyle;
 
 @end

--- a/DAModularTableView/DAModularTableViewController.m
+++ b/DAModularTableView/DAModularTableViewController.m
@@ -24,15 +24,36 @@
     if (self)
     {
         self.style = style;
+        self.frame = [[UIScreen mainScreen] applicationFrame];
+    }
+    return self;
+}
+
+- (id)initWithFrame:(CGRect)aFrame style:(UITableViewStyle)aStyle
+{
+    self = [super initWithStyle:aStyle];
+    if (self)
+    {
+        self.style = aStyle;
+        self.frame = aFrame;
     }
     return self;
 }
 
 - (void)loadView
 {
-    self.tableView = [[DAModularTableView alloc] initWithFrame:[[UIScreen mainScreen] applicationFrame]
-                                                         style:self.style];
+    if(!self.tableView)
+        self.tableView = [[DAModularTableView alloc] initWithFrame:self.frame style:self.style];
+    
     self.view = self.tableView;
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    
+    if(self.viewDidLoadBlock)
+        self.viewDidLoadBlock();
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation


### PR DESCRIPTION
- Add more control over the table view editing mode. Include editingAccessoryView, editingStyle, editingAccessoryType + all other properties to allow row reordering and deletion.
- Add a viewDidLoadBlock to allow table view creation without the need for subclassing. Also add a frame property for cases where the table view controller should not be full screen.
